### PR TITLE
Integrate Asset Information

### DIFF
--- a/config/domain.yaml
+++ b/config/domain.yaml
@@ -68,14 +68,14 @@ networks:
     domain: 'bmc'
     short_hostname: "<%= node.name %>.<%= config.networks.bmc.domain %>"
     ip: "<%= (node.asset.oob.ip rescue nil) || answer.bmc_network_ip_node || answer.bmc_network_ip %>"
-    netmask: "<%= node.asset.oob.netmask || answer.mgt_network_netmask %>"
-    network: "<%= node.asset.oob.network || answer.mgt_network_network %>"
+    netmask: "<%= (node.asset.oob.netmask rescue nil) || answer.mgt_network_netmask %>"
+    network: "<%= (node.asset.oob.network rescue nil) || answer.mgt_network_network %>"
     gateway: 0.0.0.0
-    bmcpassword: "<%= node.asset.oob.password || answer.bmc_password %>"
+    bmcpassword: "<%= (node.asset.oob.password rescue nil) || answer.bmc_password %>"
     bmcchannel: 1
-    bmcuser: <%= node.asset.oob.user || 'admin' %>
+    bmcuser: <%= (node.asset.oob.user rescue nil) || 'admin' %>
     bmcuserid: 2
-    bmcvlan: <%= node.asset.oob.vlan || answer.bmc_network_vlan %>
+    bmcvlan: <%= (node.asset.oob.vlan rescue nil) || answer.bmc_network_vlan %>
 
 disklabel: 'sda'
 disksetup: |

--- a/config/domain.yaml
+++ b/config/domain.yaml
@@ -67,15 +67,15 @@ networks:
     hostname: "<%= config.networks.bmc.short_hostname %>.<%= config.networks.mgt.domain %>.<%= config.domain %>"
     domain: 'bmc'
     short_hostname: "<%= node.name %>.<%= config.networks.bmc.domain %>"
-    ip: "<%= answer.bmc_network_ip_node || answer.bmc_network_ip %>"
-    netmask: "<%= answer.mgt_network_netmask %>"
-    network: "<%= answer.mgt_network_network %>"
+    ip: "<%= (node.asset.oob.ip rescue nil) || answer.bmc_network_ip_node || answer.bmc_network_ip %>"
+    netmask: "<%= (node.asset.oob.netmask rescue answer.mgt_network_netmask) %>"
+    network: "<%= (node.asset.oob.network rescue answer.mgt_network_network) %>"
     gateway: 0.0.0.0
-    bmcpassword: "<%= answer.bmc_password %>"
+    bmcpassword: "<%= (node.asset.oob.password rescue answer.bmc_password) %>"
     bmcchannel: 1
-    bmcuser: admin
+    bmcuser: <%= (node.asset.oob.user rescue 'admin') %>
     bmcuserid: 2
-    bmcvlan: <%= answer.bmc_network_vlan %>
+    bmcvlan: <%= (node.asset.oob.vlan rescue answer.bmc_network_vlan) %>
 
 disklabel: 'sda'
 disksetup: |

--- a/config/domain.yaml
+++ b/config/domain.yaml
@@ -68,14 +68,14 @@ networks:
     domain: 'bmc'
     short_hostname: "<%= node.name %>.<%= config.networks.bmc.domain %>"
     ip: "<%= (node.asset.oob.ip rescue nil) || answer.bmc_network_ip_node || answer.bmc_network_ip %>"
-    netmask: "<%= (node.asset.oob.netmask rescue answer.mgt_network_netmask) %>"
-    network: "<%= (node.asset.oob.network rescue answer.mgt_network_network) %>"
+    netmask: "<%= node.asset.oob.netmask || answer.mgt_network_netmask %>"
+    network: "<%= node.asset.oob.network || answer.mgt_network_network %>"
     gateway: 0.0.0.0
-    bmcpassword: "<%= (node.asset.oob.password rescue answer.bmc_password) %>"
+    bmcpassword: "<%= node.asset.oob.password || answer.bmc_password %>"
     bmcchannel: 1
-    bmcuser: <%= (node.asset.oob.user rescue 'admin') %>
+    bmcuser: <%= node.asset.oob.user || 'admin' %>
     bmcuserid: 2
-    bmcvlan: <%= (node.asset.oob.vlan rescue answer.bmc_network_vlan) %>
+    bmcvlan: <%= node.asset.oob.vlan || answer.bmc_network_vlan %>
 
 disklabel: 'sda'
 disksetup: |

--- a/hosts/default
+++ b/hosts/default
@@ -5,3 +5,23 @@
 <% end -%>
 <% end %>
 <% end -%>
+
+# PDUs
+<% assets.pdus.each do |pdu| -%>
+<%= pdu.oob.ip %> <%= pdu.metadata.name %>
+<% end -%>
+
+# Switches
+<% assets.switches.each do |switch| -%>
+<%= switch.oob.ip %> <%= switch.metadata.name %>
+<% end -%>
+
+# Disk Arrays
+<% assets.disk_arrays.each do |disk_array| -%>
+<%= disk_array.oob.ip %> <%= disk_array.metadata.name %>
+<% end -%>
+
+# Chassis
+<% assets.chassis.each do |chassis| -%>
+<%= chassis.oob.ip %> <%= chassis.metadata.name %>
+<% end -%>

--- a/named/forward/default
+++ b/named/forward/default
@@ -23,3 +23,31 @@ IN NS <%= domain.hostip %>.
 <%             end -%>
 <%         end -%>
 <%     end -%>
+
+# PDUs
+<%     assets.pdus.each do |pdu| -%>
+<%         if pdu.oob.network.to_s == alces.named.net.network.to_s -%>
+<%= pdu.metadata.name %> IN A <%= pdu.oob.ip %>
+<%         end -%>
+<%     end -%>
+
+# Switches
+<%     assets.switches.each do |switch| -%>
+<%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
+<%= switch.metadata.name %> IN A <%= switch.oob.ip %>
+<%         end -%>
+<%     end -%>
+
+# Disk Arrays
+<%     assets.disk_arrays.each do |disk_array| -%>
+<%         if disk_array.oob.network.to_s == alces.named.net.network.to_s -%>
+<%= disk_array.metadata.name %> IN A <%= disk_array.oob.ip %>
+<%         end -%>
+<%     end -%>
+
+# Chassis
+<%     assets.chassis.each do |chassis| -%>
+<%         if chassis.oob.network.to_s == alces.named.net.network.to_s -%>
+<%= chassis.metadata.name %> IN A <%= chassis.oob.ip %>
+<%         end -%>
+<%     end -%>

--- a/named/forward/default
+++ b/named/forward/default
@@ -32,7 +32,7 @@ IN NS <%= domain.hostip %>.
 <%     end -%>
 
 # Switches
-<%     assets.switches.each do |switch| -%>
+<%     assets.network_switches.each do |switch| -%>
 <%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
 <%= switch.metadata.name %> IN A <%= switch.oob.ip %>
 <%         end -%>

--- a/named/forward/default
+++ b/named/forward/default
@@ -24,28 +24,28 @@ IN NS <%= domain.hostip %>.
 <%         end -%>
 <%     end -%>
 
-# PDUs
+; PDUs
 <%     assets.pdus.each do |pdu| -%>
 <%         if pdu.oob.network.to_s == alces.named.net.network.to_s -%>
 <%= pdu.metadata.name %> IN A <%= pdu.oob.ip %>;
 <%         end -%>
 <%     end -%>
 
-# Switches
+; Switches
 <%     assets.network_switches.each do |switch| -%>
 <%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
 <%= switch.metadata.name %> IN A <%= switch.oob.ip %>;
 <%         end -%>
 <%     end -%>
 
-# Disk Arrays
+; Disk Arrays
 <%     assets.disk_arrays.each do |disk_array| -%>
 <%         if disk_array.oob.network.to_s == alces.named.net.network.to_s -%>
 <%= disk_array.metadata.name %> IN A <%= disk_array.oob.ip %>;
 <%         end -%>
 <%     end -%>
 
-# Chassis
+; Chassis
 <%     assets.chassis.each do |chassis| -%>
 <%         if chassis.oob.network.to_s == alces.named.net.network.to_s -%>
 <%= chassis.metadata.name %> IN A <%= chassis.oob.ip %>;

--- a/named/forward/default
+++ b/named/forward/default
@@ -27,27 +27,27 @@ IN NS <%= domain.hostip %>.
 # PDUs
 <%     assets.pdus.each do |pdu| -%>
 <%         if pdu.oob.network.to_s == alces.named.net.network.to_s -%>
-<%= pdu.metadata.name %> IN A <%= pdu.oob.ip %>
+<%= pdu.metadata.name %> IN A <%= pdu.oob.ip %>;
 <%         end -%>
 <%     end -%>
 
 # Switches
 <%     assets.network_switches.each do |switch| -%>
 <%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
-<%= switch.metadata.name %> IN A <%= switch.oob.ip %>
+<%= switch.metadata.name %> IN A <%= switch.oob.ip %>;
 <%         end -%>
 <%     end -%>
 
 # Disk Arrays
 <%     assets.disk_arrays.each do |disk_array| -%>
 <%         if disk_array.oob.network.to_s == alces.named.net.network.to_s -%>
-<%= disk_array.metadata.name %> IN A <%= disk_array.oob.ip %>
+<%= disk_array.metadata.name %> IN A <%= disk_array.oob.ip %>;
 <%         end -%>
 <%     end -%>
 
 # Chassis
 <%     assets.chassis.each do |chassis| -%>
 <%         if chassis.oob.network.to_s == alces.named.net.network.to_s -%>
-<%= chassis.metadata.name %> IN A <%= chassis.oob.ip %>
+<%= chassis.metadata.name %> IN A <%= chassis.oob.ip %>;
 <%         end -%>
 <%     end -%>

--- a/named/reverse/default
+++ b/named/reverse/default
@@ -21,3 +21,35 @@ $TTL 300
 <%             end -%>
 <%         end -%>
 <%     end -%>
+
+# PDUs
+<%     assets.pdus.each do |pdu| -%>
+<%         if pdu.oob.network.to_s == alces.named.net.network.to_s -%>
+<% ip_split = pdu.oob.network.ip.split(/\./) -%>
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= pdu.metadata.name %>
+<%         end -%>
+<%     end -%>
+
+# Switches
+<%     assets.switches.each do |switch| -%>
+<%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
+<% ip_split = switch.oob.network.ip.split(/\./) -%>
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= switch.metadata.name %>
+<%         end -%>
+<%     end -%>
+
+# Disk Arrays
+<%     assets.disk_arrays.each do |disk_array| -%>
+<%         if disk_array.oob.network.to_s == alces.named.net.network.to_s -%>
+<% ip_split = disk_array.oob.network.ip.split(/\./) -%>
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= disk_array.metadata.name %>
+<%         end -%>
+<%     end -%>
+
+# Chassis
+<%     assets.chassis.each do |chassis| -%>
+<%         if chassis.oob.network.to_s == alces.named.net.network.to_s -%>
+<% ip_split = chassis.oob.network.ip.split(/\./) -%>
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= chassis.metadata.name %>
+<%         end -%>
+<%     end -%>

--- a/named/reverse/default
+++ b/named/reverse/default
@@ -31,7 +31,7 @@ $TTL 300
 <%     end -%>
 
 # Switches
-<%     assets.switches.each do |switch| -%>
+<%     assets.network_switches.each do |switch| -%>
 <%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = switch.oob.network.ip.split(/\./) -%>
 <%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= switch.metadata.name %>

--- a/named/reverse/default
+++ b/named/reverse/default
@@ -25,7 +25,7 @@ $TTL 300
 # PDUs
 <%     assets.pdus.each do |pdu| -%>
 <%         if pdu.oob.network.to_s == alces.named.net.network.to_s -%>
-<% ip_split = pdu.oob.network.ip.split(/\./) -%>
+<% ip_split = pdu.oob.ip.split(/\./) -%>
 <%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= pdu.metadata.name %>
 <%         end -%>
 <%     end -%>
@@ -33,7 +33,7 @@ $TTL 300
 # Switches
 <%     assets.network_switches.each do |switch| -%>
 <%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
-<% ip_split = switch.oob.network.ip.split(/\./) -%>
+<% ip_split = switch.oob.ip.split(/\./) -%>
 <%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= switch.metadata.name %>
 <%         end -%>
 <%     end -%>
@@ -41,7 +41,7 @@ $TTL 300
 # Disk Arrays
 <%     assets.disk_arrays.each do |disk_array| -%>
 <%         if disk_array.oob.network.to_s == alces.named.net.network.to_s -%>
-<% ip_split = disk_array.oob.network.ip.split(/\./) -%>
+<% ip_split = disk_array.oob.ip.split(/\./) -%>
 <%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= disk_array.metadata.name %>
 <%         end -%>
 <%     end -%>
@@ -49,7 +49,7 @@ $TTL 300
 # Chassis
 <%     assets.chassis.each do |chassis| -%>
 <%         if chassis.oob.network.to_s == alces.named.net.network.to_s -%>
-<% ip_split = chassis.oob.network.ip.split(/\./) -%>
+<% ip_split = chassis.oob.ip.split(/\./) -%>
 <%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= chassis.metadata.name %>
 <%         end -%>
 <%     end -%>

--- a/named/reverse/default
+++ b/named/reverse/default
@@ -26,7 +26,7 @@ $TTL 300
 <%     assets.pdus.each do |pdu| -%>
 <%         if pdu.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = pdu.oob.ip.split(/\./) -%>
-<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= pdu.metadata.name %>
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= pdu.metadata.name %>;
 <%         end -%>
 <%     end -%>
 
@@ -34,7 +34,7 @@ $TTL 300
 <%     assets.network_switches.each do |switch| -%>
 <%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = switch.oob.ip.split(/\./) -%>
-<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= switch.metadata.name %>
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= switch.metadata.name %>;
 <%         end -%>
 <%     end -%>
 
@@ -42,7 +42,7 @@ $TTL 300
 <%     assets.disk_arrays.each do |disk_array| -%>
 <%         if disk_array.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = disk_array.oob.ip.split(/\./) -%>
-<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= disk_array.metadata.name %>
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= disk_array.metadata.name %>;
 <%         end -%>
 <%     end -%>
 
@@ -50,6 +50,6 @@ $TTL 300
 <%     assets.chassis.each do |chassis| -%>
 <%         if chassis.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = chassis.oob.ip.split(/\./) -%>
-<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= chassis.metadata.name %>
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= chassis.metadata.name %>;
 <%         end -%>
 <%     end -%>

--- a/named/reverse/default
+++ b/named/reverse/default
@@ -26,7 +26,7 @@ $TTL 300
 <%     assets.pdus.each do |pdu| -%>
 <%         if pdu.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = pdu.oob.ip.split(/\./) -%>
-<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= pdu.metadata.name %>;
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= pdu.metadata.name %>.;
 <%         end -%>
 <%     end -%>
 
@@ -34,7 +34,7 @@ $TTL 300
 <%     assets.network_switches.each do |switch| -%>
 <%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = switch.oob.ip.split(/\./) -%>
-<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= switch.metadata.name %>;
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= switch.metadata.name %>.;
 <%         end -%>
 <%     end -%>
 
@@ -42,7 +42,7 @@ $TTL 300
 <%     assets.disk_arrays.each do |disk_array| -%>
 <%         if disk_array.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = disk_array.oob.ip.split(/\./) -%>
-<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= disk_array.metadata.name %>;
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= disk_array.metadata.name %>.;
 <%         end -%>
 <%     end -%>
 
@@ -50,6 +50,6 @@ $TTL 300
 <%     assets.chassis.each do |chassis| -%>
 <%         if chassis.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = chassis.oob.ip.split(/\./) -%>
-<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= chassis.metadata.name %>;
+<%= ip_split[3] %>.<%= ip_split[2] %> IN PTR <%= chassis.metadata.name %>.;
 <%         end -%>
 <%     end -%>

--- a/named/reverse/default
+++ b/named/reverse/default
@@ -22,7 +22,7 @@ $TTL 300
 <%         end -%>
 <%     end -%>
 
-# PDUs
+; PDUs
 <%     assets.pdus.each do |pdu| -%>
 <%         if pdu.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = pdu.oob.ip.split(/\./) -%>
@@ -30,7 +30,7 @@ $TTL 300
 <%         end -%>
 <%     end -%>
 
-# Switches
+; Switches
 <%     assets.network_switches.each do |switch| -%>
 <%         if switch.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = switch.oob.ip.split(/\./) -%>
@@ -38,7 +38,7 @@ $TTL 300
 <%         end -%>
 <%     end -%>
 
-# Disk Arrays
+; Disk Arrays
 <%     assets.disk_arrays.each do |disk_array| -%>
 <%         if disk_array.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = disk_array.oob.ip.split(/\./) -%>
@@ -46,7 +46,7 @@ $TTL 300
 <%         end -%>
 <%     end -%>
 
-# Chassis
+; Chassis
 <%     assets.chassis.each do |chassis| -%>
 <%         if chassis.oob.network.to_s == alces.named.net.network.to_s -%>
 <% ip_split = chassis.oob.ip.split(/\./) -%>


### PR DESCRIPTION
Use asset information if present. 

This will use the following information from assets:
- OOB information (for BMCs of chassis)
- Add non-node hardware to hosts/named (like psus, pdus, etc)
- Use network port names from `network_adapter` assets which match the cable colour for the network (*question:* How do we assign a cable colour from a `network` asset to `config.networks`? Some form of linking?)