### PR TITLE
Update hunter access following namespace change

### DIFF
--- a/dhcp/default
+++ b/dhcp/default
@@ -1,5 +1,5 @@
 
-<% alces.hunter.each do |hostname, mac_address| %>
+<% alces.data.hunter.each do |hostname, mac_address| %>
 host <%= hostname %> {
   hardware ethernet <%= mac_address %>;
   option host-name "<%= hostname %>.<%= config.networks.pri.domain %>.<%= config.domain %>";


### PR DESCRIPTION
Supporting change required to access `hunter` data from new location, following https://github.com/alces-software/metalware/pull/454.

FYI you'll also need to make the corresponding change to any other places you use `hunter` data - I couldn't see any in this repo, and have already updated [`metalware-default`](https://github.com/alces-software/metalware-default/commit/8f9a16a37b74fafcc6492b0916610bd980f6f113) (since that''s what we use in development, not sure if it's used anywhere else any more though), but you may have other repos/plugins requiring this change.